### PR TITLE
#198 fix exhibition references

### DIFF
--- a/server/database/mongodbScripts/fullStepsConverterScript.js
+++ b/server/database/mongodbScripts/fullStepsConverterScript.js
@@ -471,7 +471,7 @@ function upsertGuests(stepsGuestObj, callback) {
                                 (exhibitionAttendance, callback) => {
                                   // For each Exhibition Attendance in Parallel, 5 at a time
                                   const exhibitionQuery = {
-                                    _id: exhibitionAttendance._id,
+                                    _id: exhibitionAttendance.attendance_key,
                                     event_name: eventName,
                                   };
 

--- a/server/database/objectClasses/Attendance.js
+++ b/server/database/objectClasses/Attendance.js
@@ -21,7 +21,7 @@ class Attendance {
    */
   static connectDB() {
     this.ModelHandler = new ModelHandler()
-          .initWithParameters(username, password, host, port, dbName);
+      .initWithParameters(username, password, host, port, dbName);
     this.AttendanceModel = this.ModelHandler.getAttendanceModel();
   }
 
@@ -47,7 +47,7 @@ class Attendance {
    */
   constructor(userEmail, attendanceKey, attendanceType, reason) {
     this.ModelHandler = new ModelHandler()
-        .initWithParameters(username, password, host, port, dbName);
+      .initWithParameters(username, password, host, port, dbName);
     this.AttendanceModel = this.ModelHandler.getAttendanceModel();
     this.attendanceModelDoc = new this.AttendanceModel({
       user_email: userEmail,
@@ -65,9 +65,9 @@ class Attendance {
    */
   saveAttendance(callback) {
     Attendance.connectDB();
-    this.attendanceModelDoc.save((err) => {
+    this.attendanceModelDoc.save((err, result) => {
       Attendance.disconnectDB();
-      callback(err);
+      callback(err, result);
     });
   }
 
@@ -79,16 +79,14 @@ class Attendance {
    * @param {mongoose.Schema.ObjectId} attendanceKey: The ObjectID of the Event / Exhibition.
    *    Does not check if the Event / Exhibition exists or not.
    *    Use attendanceType to determine if tthis is for an Exhibition, or an Event.
-   * @param {String} attendanceType: Supposed to be a String enum
-   *    containing either 'event' or 'exhibition'.
    *    Used to determine the type of activity attendanceName represents.
    * @param {function} callback: A function that executes once the operation completes.
    */
-  static getAttendance(userEmail, attendanceKey, attendanceType, callback) {
+  static getAttendance(userEmail, attendanceKey, callback) {
     Attendance.connectDB();
-    const query = { user_email: userEmail,
+    const query = {
+      user_email: userEmail,
       attendance_key: attendanceKey,
-      attendance_type: attendanceType,
     };
     this.AttendanceModel.findOne(query, (err, attendance) => {
       Attendance.disconnectDB();
@@ -111,7 +109,7 @@ class Attendance {
   }
 
   /**
-   * Retrieve the Attendance Documents that contain a User's email.
+   * Retrieve the Attendance Documents that contain the User's email.
    *
    * @param {String} userEmail: Used to match against the user_emails contained in all Attendances.
    * @param {function} callback: A function that executes once the
@@ -126,38 +124,16 @@ class Attendance {
   }
 
   /**
-   * Retrieve the Attendance Documents that contain the specified Event / Exhibition name.
+   * Retrieve the Attendance Documents that contain the specified Event / Exhibition ID
    *
    * @param {mongoose.Schema.ObjectId} attendanceKey: Used to match against the
    *    attendance_key contained in all Attendances.
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static searchAttendancesByName(attendanceKey, callback) {
+  static searchAttendancesByKey(attendanceKey, callback) {
     Attendance.connectDB();
     this.AttendanceModel.find({ attendance_key: attendanceKey }, (err, matchedAttendances) => {
-      Attendance.disconnectDB();
-      callback(err, matchedAttendances);
-    });
-  }
-
-  /**
-   * Retrieve the Attendance Documents that contain the specified Event / Exhibition name.
-   *
-   * @param {mongoose.Schema.ObjectId} attendanceKey: Used to match against the
-   *    attendance_key contained in all Attendances.
-   * @param {String} attendanceType: A String enum that is supposed
-   *    to be either 'event' or 'exhibition'.
-   * @param {function} callback: A function that executes once the
-   *    operation is done.
-   */
-  static searchAttendancesByNameAndType(attendanceKey, attendanceType, callback) {
-    Attendance.connectDB();
-    const query = {
-      attendance_key: attendanceKey,
-      attendance_type: attendanceType,
-    };
-    this.AttendanceModel.find(query, (err, matchedAttendances) => {
       Attendance.disconnectDB();
       callback(err, matchedAttendances);
     });
@@ -193,11 +169,11 @@ class Attendance {
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static searchAttendanceByNameAndReason(attendanceKey, reasons, callback) {
+  static searchAttendanceByKeyAndReason(attendanceKey, reasons, callback) {
     Attendance.connectDB();
     const query = { attendance_key: attendanceKey,
-      reason: { $regex: new RegExp(reasons.replace('+', '\\+'), 'i') },
-    };
+                   reason: { $regex: new RegExp(reasons.replace('+', '\\+'), 'i') },
+                  };
     this.AttendanceModel.find(query, (err, matchedAttendances) => {
       Attendance.disconnectDB();
       callback(err, matchedAttendances);
@@ -211,27 +187,25 @@ class Attendance {
    * @param {mongoose.Schema.ObjectId} attendanceKey: The ObjectID of the Event / Exhibition.
    *    Does not check if the Event / Exhibition exists or not.
    *    Use attendanceType to determine if tthis is for an Exhibition, or an Event.
-   * @param {String} attendanceType: Supposed to be a String enum
-   *    containing either 'event' or 'exhibition'.
    *    Used to determine the type of activity attendanceName represents.
    * @param {Array} reason: The User's reasons for attending the Event.
    *    Each reason is a unique String element of the Array.
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static updateReason(userEmail, attendanceKey, attendanceType, reason, callback) {
+  static updateReason(userEmail, attendanceKey, reason, callback) {
     Attendance.connectDB();
-    const query = { user_email: userEmail,
+    const query = {
+      user_email: userEmail,
       attendance_key: attendanceKey,
-      attendance_type: attendanceType,
     };
     const update = { $set: { reason } };
     const options = { new: true };
     this.AttendanceModel.findOneAndUpdate(query, update, options,
-                                         (err, results) => {
-                                           Attendance.disconnectDB();
-                                           callback(err, results);
-                                         });
+                                          (err, results) => {
+      Attendance.disconnectDB();
+      callback(err, results);
+    });
   }
 
   /**
@@ -240,16 +214,13 @@ class Attendance {
    * @param {String} userEmail: The name for Users to match for the Attendance Document.
    * @param {mongoose.Schema.ObjectId} attendanceKey: Used to match against the
    *    attendance_key contained in all Attendances.
-   * @param {String} attendanceType: Supposed to be a String enum
-   *    containing either 'event' or 'exhibition'.
-   *    Used to determine the type of activity attendanceName represents.
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static deleteAttendance(userEmail, attendanceKey, attendanceType, callback) {
-    const query = { user_email: userEmail,
+  static deleteAttendance(userEmail, attendanceKey, callback) {
+    const query = {
+      user_email: userEmail,
       attendance_key: attendanceKey,
-      attendance_type: attendanceType,
     };
     Attendance.connectDB();
     this.AttendanceModel.findOneAndRemove(query, (err) => {

--- a/server/database/objectClasses/Attendance.js
+++ b/server/database/objectClasses/Attendance.js
@@ -172,8 +172,8 @@ class Attendance {
   static searchAttendanceByKeyAndReason(attendanceKey, reasons, callback) {
     Attendance.connectDB();
     const query = { attendance_key: attendanceKey,
-                   reason: { $regex: new RegExp(reasons.replace('+', '\\+'), 'i') },
-                  };
+      reason: { $regex: new RegExp(reasons.replace('+', '\\+'), 'i') },
+    };
     this.AttendanceModel.find(query, (err, matchedAttendances) => {
       Attendance.disconnectDB();
       callback(err, matchedAttendances);
@@ -203,9 +203,9 @@ class Attendance {
     const options = { new: true };
     this.AttendanceModel.findOneAndUpdate(query, update, options,
                                           (err, results) => {
-      Attendance.disconnectDB();
-      callback(err, results);
-    });
+                                            Attendance.disconnectDB();
+                                            callback(err, results);
+                                          });
   }
 
   /**

--- a/server/database/objectClasses/Attendance.js
+++ b/server/database/objectClasses/Attendance.js
@@ -36,22 +36,22 @@ class Attendance {
    * Creates an Attendance Document and stores it internally.
    *
    * @param {String} userEmail: The name for Users. Does not check if User actually exists or not.
-   * @param {String} attendanceName: The name of the Event / Exhibition.
+   * @param {mongoose.Schema.ObjectId} attendanceKey: The ObjectId of the Event / Exhibition.
    *    Does not check if the Event / Exhibition exists or not.
-   *    Use attendanceType to determine if the name is for an Exhibition, or an Event.
+   *    Use attendanceType to determine if this is for an Exhibition, or an Event.
    * @param {String} attendanceType: Supposed to be a String enum
    *    containing either 'event' or 'exhibition'.
    *    Used to determine the type of activity attendanceName represents.
    * @param {Array} reason: The User's reasons for attending the Event.
    *    Each reason is a unique String element of the Array.
    */
-  constructor(userEmail, attendanceName, attendanceType, reason) {
+  constructor(userEmail, attendanceKey, attendanceType, reason) {
     this.ModelHandler = new ModelHandler()
         .initWithParameters(username, password, host, port, dbName);
     this.AttendanceModel = this.ModelHandler.getAttendanceModel();
     this.attendanceModelDoc = new this.AttendanceModel({
       user_email: userEmail,
-      attendance_name: attendanceName,
+      attendance_key: attendanceKey,
       attendance_type: attendanceType,
       reason,
     });
@@ -76,18 +76,18 @@ class Attendance {
    * Using a User's email, Attendance name and type as the unique identifer.
    *
    * @param {String} userEmail: The name for Users. Does not check if User actually exists or not.
-   * @param {String} attendanceName: The name of the Event / Exhibition.
+   * @param {mongoose.Schema.ObjectId} attendanceKey: The ObjectID of the Event / Exhibition.
    *    Does not check if the Event / Exhibition exists or not.
-   *    Use attendanceType to determine if the name is for an Exhibition, or an Event.
+   *    Use attendanceType to determine if tthis is for an Exhibition, or an Event.
    * @param {String} attendanceType: Supposed to be a String enum
    *    containing either 'event' or 'exhibition'.
    *    Used to determine the type of activity attendanceName represents.
    * @param {function} callback: A function that executes once the operation completes.
    */
-  static getAttendance(userEmail, attendanceName, attendanceType, callback) {
+  static getAttendance(userEmail, attendanceKey, attendanceType, callback) {
     Attendance.connectDB();
     const query = { user_email: userEmail,
-      attendance_name: attendanceName,
+      attendance_key: attendanceKey,
       attendance_type: attendanceType,
     };
     this.AttendanceModel.findOne(query, (err, attendance) => {
@@ -128,14 +128,14 @@ class Attendance {
   /**
    * Retrieve the Attendance Documents that contain the specified Event / Exhibition name.
    *
-   * @param {String} attendanceName: Used to match against the
-   *    attendance_name contained in all Attendances.
+   * @param {mongoose.Schema.ObjectId} attendanceKey: Used to match against the
+   *    attendance_key contained in all Attendances.
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static searchAttendancesByName(attendanceName, callback) {
+  static searchAttendancesByName(attendanceKey, callback) {
     Attendance.connectDB();
-    this.AttendanceModel.find({ attendance_name: attendanceName }, (err, matchedAttendances) => {
+    this.AttendanceModel.find({ attendance_key: attendanceKey }, (err, matchedAttendances) => {
       Attendance.disconnectDB();
       callback(err, matchedAttendances);
     });
@@ -144,17 +144,17 @@ class Attendance {
   /**
    * Retrieve the Attendance Documents that contain the specified Event / Exhibition name.
    *
-   * @param {String} attendanceName: Used to match against the
-   *    attendance_name contained in all Attendances.
+   * @param {mongoose.Schema.ObjectId} attendanceKey: Used to match against the
+   *    attendance_key contained in all Attendances.
    * @param {String} attendanceType: A String enum that is supposed
    *    to be either 'event' or 'exhibition'.
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static searchAttendancesByNameAndType(attendanceName, attendanceType, callback) {
+  static searchAttendancesByNameAndType(attendanceKey, attendanceType, callback) {
     Attendance.connectDB();
     const query = {
-      attendance_name: attendanceName,
+      attendance_key: attendanceKey,
       attendance_type: attendanceType,
     };
     this.AttendanceModel.find(query, (err, matchedAttendances) => {
@@ -186,16 +186,16 @@ class Attendance {
    * Retrieve the Attendance Documents that have the Event / Exhibition name and the specified
    * reasons for attending above-mentioned activity.
    *
-   * @param {String} attendanceName: Used to match against the
-   *    attendance_name contained in all Attendances.
+   * @param {mongoose.Schema.ObjectId} attendanceKey: Used to match against the
+   *    attendance_key contained in all Attendances.
    * @param {Array} reasons: An array of Strings indicating reasons
    *    for Attending an Event / Exhibition to match for.
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static searchAttendanceByNameAndReason(attendanceName, reasons, callback) {
+  static searchAttendanceByNameAndReason(attendanceKey, reasons, callback) {
     Attendance.connectDB();
-    const query = { attendance_name: attendanceName,
+    const query = { attendance_key: attendanceKey,
       reason: { $regex: new RegExp(reasons.replace('+', '\\+'), 'i') },
     };
     this.AttendanceModel.find(query, (err, matchedAttendances) => {
@@ -208,9 +208,9 @@ class Attendance {
    * Update the Attendance Document stored internally in this object.
    *
    * @param {String} userEmail: The name for Users. Does not check if User actually exists or not.
-   * @param {String} attendanceName: The name of the Event / Exhibition.
+   * @param {mongoose.Schema.ObjectId} attendanceKey: The ObjectID of the Event / Exhibition.
    *    Does not check if the Event / Exhibition exists or not.
-   *    Use attendanceType to determine if the name is for an Exhibition, or an Event.
+   *    Use attendanceType to determine if tthis is for an Exhibition, or an Event.
    * @param {String} attendanceType: Supposed to be a String enum
    *    containing either 'event' or 'exhibition'.
    *    Used to determine the type of activity attendanceName represents.
@@ -219,10 +219,10 @@ class Attendance {
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static updateReason(userEmail, attendanceName, attendanceType, reason, callback) {
+  static updateReason(userEmail, attendanceKey, attendanceType, reason, callback) {
     Attendance.connectDB();
     const query = { user_email: userEmail,
-      attendance_name: attendanceName,
+      attendance_key: attendanceKey,
       attendance_type: attendanceType,
     };
     const update = { $set: { reason } };
@@ -238,17 +238,17 @@ class Attendance {
    * Deletes a single Attendance Document from the Database.
    *
    * @param {String} userEmail: The name for Users to match for the Attendance Document.
-   * @param {String} attendanceName: The name of the Event / Exhibition
-   *    to match for the Attendance Document.
+   * @param {mongoose.Schema.ObjectId} attendanceKey: Used to match against the
+   *    attendance_key contained in all Attendances.
    * @param {String} attendanceType: Supposed to be a String enum
    *    containing either 'event' or 'exhibition'.
    *    Used to determine the type of activity attendanceName represents.
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static deleteAttendance(userEmail, attendanceName, attendanceType, callback) {
+  static deleteAttendance(userEmail, attendanceKey, attendanceType, callback) {
     const query = { user_email: userEmail,
-      attendance_name: attendanceName,
+      attendance_key: attendanceKey,
       attendance_type: attendanceType,
     };
     Attendance.connectDB();

--- a/server/database/objectClasses/Comment.js
+++ b/server/database/objectClasses/Comment.js
@@ -35,17 +35,17 @@ class Comment {
    * Creates a Comment Document and stores it internally.
    *
    * @param {String} userEmail: The email of the User that made the Comment.
-   * @param {String} exhibitionName: The name of Exhibition with the Comment.
+   * @param {mongoose.Schema.ObjectId} exhibitionKey: The ObjectId of the Exhibition.
    * @param {String} comment: The content of the Comment.
-   * @param {Date} date: date object to indicate when the Comment was made.
+   * @param {Date} date: Date object to indicate when the Comment was made.
    */
-  constructor(userEmail, exhibitionName, comment, date) {
+  constructor(userEmail, exhibitionKey, comment, date) {
     this.ModelHandler = new ModelHandler()
         .initWithParameters(username, password, host, port, dbName);
     this.CommentModel = this.ModelHandler.getCommentModel();
     this.commentModelDoc = new this.CommentModel({
       user_email: userEmail,
-      exhibition: exhibitionName,
+      exhibition_key: exhibitionKey,
       comments: { content: comment, timestamp: date },
     });
     this.ModelHandler.disconnect();
@@ -58,9 +58,9 @@ class Comment {
    */
   saveComment(callback) {
     Comment.connectDB();
-    this.commentModelDoc.save((err) => {
+    this.commentModelDoc.save((err, result) => {
       Comment.disconnectDB();
-      callback(err);
+      callback(err, result);
     });
   }
 
@@ -68,16 +68,16 @@ class Comment {
    * Adds a Comment made by a specific User of a Comment Document.
    *
    * @param {String} userEmail: User that made the Comment.
-   * @param {String} exhibitionName: name of exhibition with the Comment.
-   * @param {String} comment: string content of the Comment.
-   * @param {Date} date: date object to indicate when the Comment is made.
+   * @param {mongoose.Schema.ObjectId} exhibitionKey: The ObjectId of the Exhibition.
+   * @param {String} comment: String content of the Comment.
+   * @param {Date} date: Date object to indicate when the Comment is made.
    * @param {function} callback: A function that is executed once the operation is done.
    */
-  static addCommentForExhibition(userEmail, exhibitionName, comment, date, callback) {
+  static addCommentForExhibition(userEmail, exhibitionKey, comment, date, callback) {
     Comment.connectDB();
     const query = {
       user_email: userEmail,
-      exhibition: exhibitionName,
+      exhibition_key: exhibitionKey,
     };
     const update = { $push: { comments: { content: comment, timestamp: date } } };
     const options = { new: true };
@@ -90,12 +90,12 @@ class Comment {
   /**
    * Retrieve list of Comments for a specific Exhibition.
    *
-   * @param {String} exhibitionName: name of Exhibition to retrieve Comments for.
+   * @param {mongoose.Schema.ObjectId} exhibitionKey: The ObjectID of the Exhibition.
    * @param {function} callback: A function that is executed once the operation is done.
    */
-  static getCommentsForExhibition(exhibitionName, callback) {
+  static getCommentsForExhibition(exhibitionKey, callback) {
     Comment.connectDB();
-    this.CommentModel.find({ exhibition: exhibitionName }, (err, matchedComments) => {
+    this.CommentModel.find({ exhibition_key: exhibitionKey }, (err, matchedComments) => {
       Comment.disconnectDB();
       callback(err, matchedComments);
     });
@@ -104,12 +104,12 @@ class Comment {
   /**
    * Removes Comments for a specific Exhibition.
    *
-   * @param {String} exhibitionName: name of Exhibition to clear Comments from.
+   * @param {mongoose.Schema.ObjectId} exhibitionKey: The ObjectId of the Exhibition.
    * @param {function} callback: A function that is executed once the operation is done.
    */
-  static clearCommentsForExhibition(exhibitionName, callback) {
+  static clearCommentsForExhibition(exhibitionKey, callback) {
     Comment.connectDB();
-    this.CommentModel.find({ exhibition_name: exhibitionName }).remove().exec((err, results) => {
+    this.CommentModel.find({ exhibition_key: exhibitionKey }).remove().exec((err, results) => {
       Comment.disconnectDB();
       callback(err, results);
     });
@@ -120,7 +120,7 @@ class Comment {
    *
    * @param {function} callback: A function that is executed once the operation is done.
    */
-  static clearAllComment(callback) {
+  static clearAllComments(callback) {
     Comment.connectDB();
     this.CommentModel.collection.remove({}, (err) => {
       Comment.disconnectDB();

--- a/server/database/objectClasses/Event.js
+++ b/server/database/objectClasses/Event.js
@@ -69,9 +69,9 @@ class Event {
    */
   saveEvent(callback) {
     Event.connectDB();
-    this.eventModelDoc.save((err) => {
+    this.eventModelDoc.save((err, result) => {
       Event.disconnectDB();
-      callback(err);
+      callback(err, result);
     });
   }
 

--- a/server/database/objectClasses/Exhibition.js
+++ b/server/database/objectClasses/Exhibition.js
@@ -77,35 +77,39 @@ class Exhibition {
   /**
    * Checks whether the Exhibition exists within the Database. Will callback a boolean value.
    *
+   * @param {String} eventName: The name of the Event that the Exhibition is held in.
    * @param {String} exhibitionName: The name of the Exhibition to search for.
    * @param {function} callback: A function that is executed once the operation is done.
    */
-  static isExistingExhibition(exhibitionName, callback) {
+  static isExistingExhibition(eventName, exhibitionName, callback) {
     Exhibition.connectDB();
-    this.ExhibitionModel.findOne({ exhibition_name: exhibitionName }, (err, exhibition) => {
-      Exhibition.disconnectDB();
-      if (err) {
-        callback(err, false);
-      } else if (exhibition) {
-        callback(null, true);
-      } else {
-        callback(null, false);
-      }
-    });
+    this.ExhibitionModel.findOne({ event_name: eventName, exhibition_name: exhibitionName },
+        (err, exhibition) => {
+          Exhibition.disconnectDB();
+          if (err) {
+            callback(err, false);
+          } else if (exhibition) {
+            callback(null, true);
+          } else {
+            callback(null, false);
+          }
+        });
   }
 
   /**
    * Retrieve a specific Exhibition in the Database.
    *
+   * @param {String} eventName: The name of the Event of which the Exhibition is held in.
    * @param {String} exhibitionName: The name of the Exhibition to retrieve from the Database.
    * @param {function} callback: A function that is executed once the operation is done.
    */
-  static getExhibition(exhibitionName, callback) {
+  static getExhibition(eventName, exhibitionName, callback) {
     Exhibition.connectDB();
-    this.ExhibitionModel.findOne({ exhibition_name: exhibitionName }, (err, exhibition) => {
-      Exhibition.disconnectDB();
-      callback(err, exhibition);
-    });
+    this.ExhibitionModel.findOne({ event_name: eventName, exhibition_name: exhibitionName },
+        (err, exhibition) => {
+          Exhibition.disconnectDB();
+          callback(err, exhibition);
+        });
   }
 
   /**

--- a/server/database/objectClasses/Exhibition.js
+++ b/server/database/objectClasses/Exhibition.js
@@ -68,9 +68,9 @@ class Exhibition {
    */
   saveExhibition(callback) {
     Exhibition.connectDB();
-    this.exhibitionModelDoc.save((err) => {
+    this.exhibitionModelDoc.save((err, result) => {
       Exhibition.disconnectDB();
-      callback(err);
+      callback(err, result);
     });
   }
 

--- a/server/database/schemas/ourSchemas/attendance.js
+++ b/server/database/schemas/ourSchemas/attendance.js
@@ -7,10 +7,9 @@ const attendanceSchema = new mongoose.Schema({
     required: 'The Email of the User who is attending the Event / Exhibition is used as a Foreign Key, and is t' +
         'herefore Required.',
   },
-  attendance_name: {
-    type: String,
-    trim: true,
-    required: 'The Exhibition / Event that this User is attending is used as a Foreign Key, and it is therefore Required.',
+  attendance_key: {
+    type: mongoose.Schema.ObjectId,
+    required: 'The id of the Exhibition / Event that this User is attending is used as a Foreign Key, and it is therefore Required.',
   },
   attendance_type: {
     type: String,
@@ -27,6 +26,6 @@ const attendanceSchema = new mongoose.Schema({
   ],
 });
 
-attendanceSchema.index({ user_email: 1, attendance_type: 1, attendance_name: 1 }, { unique: true });
+attendanceSchema.index({ user_email: 1, attendance_key: 1 }, { unique: true });
 
 module.exports = attendanceSchema;

--- a/server/database/schemas/ourSchemas/comment.js
+++ b/server/database/schemas/ourSchemas/comment.js
@@ -7,8 +7,8 @@ const commentSchema = new mongoose.Schema({
     required: 'The Email of the User who posted this Comment is used as a Foreign Key, and is t' +
         'herefore Required.',
   },
-  exhibition: {
-    type: String,
+  exhibition_key: {
+    type: mongoose.Schema.ObjectId,
     required: 'The Name of the Exhibition for which this Comment is posted under is used as a F' +
         'oreign Key, and is therefore Required.',
   },

--- a/tests/attendance.test.js
+++ b/tests/attendance.test.js
@@ -113,7 +113,7 @@ describe('Attendance Create', () => {
         done();
       } else{
         const attendance3 = new Attendance(
-          'usertesting_1@user.com',
+          'usertesting_2@user.com',
           result._id,
           'event',
           ['finding collabrators']
@@ -122,7 +122,7 @@ describe('Attendance Create', () => {
           if (err) {
             console.log(err);
           }
-          Attendance.searchAttendancesByUser('usertesting_1@user.com', (err, attendanceObj) => {
+          Attendance.searchAttendancesByUser('usertesting_2@user.com', (err, attendanceObj) => {
             if (err) {
               console.log('not able to get object');
               console.log(err);

--- a/tests/attendance.test.js
+++ b/tests/attendance.test.js
@@ -67,45 +67,45 @@ describe('Attendance Create', () => {
         });
       });
     });
+  });
 
-    it('Should be able to add a new exhibition attendance', (done) => {
-      //obtain exhibition_id
-      Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
-        if (err){
-          console.log(err);
-          done();
-        } else{
-          const attendance2 = new Attendance(
-            'usertesting_1@user.com',
-            result._id,
-            'exhibition',
-            ['finding investors', 'finding collabrators']
-          );
-          attendance2.saveAttendance((err) => {
+  it('Should be able to add a new exhibition attendance', (done) => {
+    //obtain exhibition_id
+    Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
+      if (err){
+        console.log(err);
+        done();
+      } else{
+        const attendance2 = new Attendance(
+          'usertesting_2@user.com',
+          result._id,
+          'exhibition',
+          ['finding investors', 'finding collabrators']
+        );
+        attendance2.saveAttendance((err) => {
+          if (err) {
+            console.log(err);
+          }
+          Attendance.searchAttendancesByUser('usertesting_2@user.com', (err, attendanceObj) => {
             if (err) {
+              console.log('not able to get object');
               console.log(err);
-            }
-            Attendance.searchAttendancesByUser('usertesting_1@user.com', (err, attendanceObj) => {
-              if (err) {
-                console.log('not able to get object');
-                console.log(err);
-              } else {
-                if(attendanceObj) {
-                  assert.equal(attendanceObj[0].attendance_type, 'exhibition');
-                }
-                else {
-                  console.log("Attendance Object not found");
-                }
+            } else {
+              if(attendanceObj) {
+                assert.equal(attendanceObj[0].attendance_type, 'exhibition');
               }
-              done();
-            });
+              else {
+                console.log("Attendance Object not found");
+              }
+            }
+            done();
           });
-        }
-      });
+        });
+      }
     });
   });
 
-  it('Should be able to add a new event attendance', (done) => {
+ it('Should be able to add a new event attendance', (done) => {
     //obtain event_id
     Event.getEvent('eventTest1', (err, result) => {
       if (err){
@@ -113,7 +113,7 @@ describe('Attendance Create', () => {
         done();
       } else{
         const attendance3 = new Attendance(
-          'usertesting_2@user.com',
+          'usertesting_3@user.com',
           result._id,
           'event',
           ['finding collabrators']
@@ -122,7 +122,7 @@ describe('Attendance Create', () => {
           if (err) {
             console.log(err);
           }
-          Attendance.searchAttendancesByUser('usertesting_2@user.com', (err, attendanceObj) => {
+          Attendance.searchAttendancesByUser('usertesting_3@user.com', (err, attendanceObj) => {
             if (err) {
               console.log('not able to get object');
               console.log(err);

--- a/tests/attendance.test.js
+++ b/tests/attendance.test.js
@@ -1,256 +1,419 @@
 const Attendance = require('../server/database/objectClasses/Attendance.js');
+const Exhibition = require('../server/database/objectClasses/Exhibition.js');
+const Event = require('../server/database/objectClasses/Event.js');
 const assert = require('assert');
 
-describe('Attendance Create', function() {
+describe('Attendance Create', () => {
 
-  before (function(done) {
-    var attendance1 = new Attendance('usertesting_1@user.com',
-                                     'eventTest1', 'event',
-                                     ['finding investors', 'finding collabrators']
-                                    );
-    attendance1.saveAttendance(function callback(err) {
+  before ((done) => {
+    const testexhibition1 = new Exhibition(
+      'MAMA! LAVA!',
+      'The description of the exhibition',
+      'STEPS',
+      'https://upload.wikimedia.org/wikipedia/en/0/02/My_Neighbor_Totoro_-_Tonari_no_Totoro_%28Movie_Poster%29.jpg',
+      ['https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1', 'https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1'],
+      ['www.youtube.com', 'www.youtube.com'],
+      'url.com',
+      ['game', 'software engineering'],
+    );
+    testexhibition1.saveExhibition((err, result) => {
       if (err) {
         console.log(err);
       }
-      done();
-    });
-  });
-
-  after(function(done) {
-    Attendance.clearAllAttendances(function callback(err) {
-      if (err) {
-        console.log(err);
-      }
-      done();
-    })
-  });
-
-  it('Should be able to add a new attendance', function(done) {
-    var attendance2 = new Attendance('usertesting_1@user.com',
-                                     'eventTest1',
-                                     'exhibition',
-                                     ['finding investors', 'finding collabrators']
-                                    );
-    attendance2.saveAttendance(function callback(err) {
-      if (err) {
-        console.log(err);
-      }
-      Attendance.searchAttendancesByUser('usertesting_1@user.com', function(err1, attendanceObj) {
-        if (err1) {
-          console.log('not able to get object');
-          console.log(err1);
-        } else {
-          if(attendanceObj) {
-            assert.equal(attendanceObj[0].attendance_name, 'eventTest1');
-          }
-          else {
-            console.log("WHY IS THERE NOTHING!??!?!");
-          }
-        }
-        done();
+      const attendance1 = new Attendance(
+        'usertesting_1@user.com',
+        result._id, 
+        'exhibition',
+        ['finding investors', 'finding collabrators']
+      );
+      attendance1.saveAttendance((err) => {
+        if (err) {
+          console.log(err);
+        }    
+        const testevent1 = new Event(
+          'eventTest1',
+          'description',
+          new Date('October 13, 2014 11:13:00'),
+          new Date('October 14, 2014 21:00:00'),
+          'NUS',
+          'map',
+          'https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1',
+          ['game', 'software engineering']
+        );
+        testevent1.saveEvent((err, result) => {
+          if (err){
+            console.log(err);
+          } 
+          done();
+        });
       });
     });
   });
-});
 
-describe('Attendance Read', function() {
-  before (function(done) {
-    var attendance1 = new Attendance('usertesting_2@user.com',
-                                     'eventNumber2', 'exhibition',
-                                     ['finding investors', 'finding collabrators']
-                                    );
-    attendance1.saveAttendance(function callback (err) {
+  after((done) => {
+    Attendance.clearAllAttendances((err) =>{
       if (err) {
         console.log(err);
       }
-      done();
+      Exhibition.clearAllExhibitions((err) => {
+        if (err){
+          console.log(err);
+        }
+        Event.clearAllEvents((err) => {
+          if (err){
+            console.log(err);
+          }
+          done();
+        });
+      });
+    });
+
+    it('Should be able to add a new exhibition attendance', (done) => {
+      //obtain exhibition_id
+      Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
+        if (err){
+          console.log(err);
+          done();
+        } else{
+          const attendance2 = new Attendance(
+            'usertesting_1@user.com',
+            result._id,
+            'exhibition',
+            ['finding investors', 'finding collabrators']
+          );
+          attendance2.saveAttendance((err) => {
+            if (err) {
+              console.log(err);
+            }
+            Attendance.searchAttendancesByUser('usertesting_1@user.com', (err, attendanceObj) => {
+              if (err) {
+                console.log('not able to get object');
+                console.log(err);
+              } else {
+                if(attendanceObj) {
+                  assert.equal(attendanceObj[0].attendance_type, 'exhibition');
+                }
+                else {
+                  console.log("Attendance Object not found");
+                }
+              }
+              done();
+            });
+          });
+        }
+      });
     });
   });
 
-  after(function(done) {
-    Attendance.clearAllAttendances(function callback(err) {
-      if (err) {
-        console.log(err);
-      }
-      done();
-    })
-  });
-
-  it('should be able to retrieve an array AttendanceObj by user email', function(done) {
-    Attendance.searchAttendancesByUser('usertesting_2@user.com', function(err, obj) {
-      if (err) {
-        console.log("unable to get attendance object");
-      } else {
-        assert.equal(obj[0].attendance_name, 'eventNumber2');
-      }
-      done();
-    });
-  });
-
-  it('should be able to get the list of attendees in an event', function(done) {
-    Attendance.searchAttendancesByNameAndType('eventNumber2', 'event', function(err, obj) {
-      if (err) {
-        console.log("unable to get attendance object");
-      } else {
-        assert.equal(obj[0], null);
-      }
-      done();
-    });
-  });
-  
-    it('should be able to get the list of exhibitioners in an event', function(done) {
-    Attendance.searchAttendancesByNameAndType('eventNumber2', 'exhibition', function(err, obj) {
-      if (err) {
-        console.log("unable to get attendance object");
-      } else {
-        assert.equal(obj[0].user_email, 'usertesting_2@user.com');
-      }
-      done();
-    });
-  });
-  
-    it('should be able to get the list of exhibitioners', function(done) {
-    Attendance.searchAttendancesByUser('usertesting_2@user.com', function(err, obj) {
-      if (err) {
-        console.log("unable to get attendance object");
-      } else {
-        assert.equal(obj[0].attendance_name, 'eventNumber2');
-      }
-      done();
-    });
-  });
-
-  it('should be able to retrieve an array of AttendanceObj by event name', function(done) {
-    Attendance.searchAttendancesByName('eventNumber2', function(err, obj) {
-      if (err) {
-        console.log("unable to get attendance object");
-      } else {
-        assert.equal(obj[0].attendance_name, 'eventNumber2');
-      }
-      done();
-    });
-  });
-
-  it('should be able to retrieve an array of AttendanceObj by reasons', function(done) {
-    Attendance.searchAttendancesByReason('investors', function(err, obj) {
-      if (err) {
-        console.log("unable to get attendance object");
-      } else {
-        assert.notEqual(obj, null);
-      }
-      done();
-    });
-  });
-
-  it('should be able to retrieve an array of AttendanceObj by attendance name and reasons', function(done){
-    Attendance.searchAttendanceByNameAndReason('eventNumber2', 'investor', function(err, obj) {
-      if (err) {
-        console.log("unable to get attendance object");
-      } else {
-        assert.notEqual(obj, null);
-      }
-      done();
-    });
-  });
-
-
-  it('should be able to obtain a specific AttedanceObj using email, event/exhibit name and type', function(done){
-    Attendance.getAttendance('usertesting_2@user.com','eventNumber2','exhibition', function(err, obj) {
-      if (err) {
-        console.log(err);
-      } else {
-        assert.equal(obj.reason[0], 'finding investors');
-      }
-      done();
-    })
-  });
-});
-
-describe('Attendance Update', function() {
-  before (function(done){
-    var attendance1 = new Attendance('usertesting_3@user.com',
-                                     'eventTest3',
-                                     'exhibition',
-                                     ['seeking investors', 'finding collabrators']
-                                    );
-    attendance1.saveAttendance(function callback (err) {
-      if (err) {
-        console.log(err);
-      }
-      done();
-    });
-  });
-
-  after(function(done) {
-    Attendance.clearAllAttendances(function callback(err) {
-      if (err) {
-        console.log(err);
-      }
-      done();
-    })
-  });
-
-  it('should be able to update reasons', function(done) {
-    Attendance.updateReason('usertesting_3@user.com',
-                            'eventTest3',
-                            'exhibition',
-                            ['Finding internship'],
-                            function callback(err, obj){
-      if (err) {
-        console.log(err);
-      } else if (obj){
-        assert.notEqual(obj,null);
-        assert.equal(obj.reason[0], 'Finding internship');
-      } else {
-        console.log("unable to find attendance object. Run test again");
-      }
-
-      done();
-    });
-  });
-
-});
-
-describe('Attendance Delete', function(){
-  before (function(done){
-    var attendance1 = new Attendance('usertesting_2@user.com', 
-                                     'eventNumber2', 'exhibition', 
-                                     ['finding investors', 'finding collabrators']
-                                    );
-    attendance1.saveAttendance(function callback (err){
+  it('Should be able to add a new event attendance', (done) => {
+    //obtain event_id
+    Event.getEvent('eventTest1', (err, result) => {
       if (err){
         console.log(err);
+        done();
+      } else{
+        const attendance3 = new Attendance(
+          'usertesting_1@user.com',
+          result._id,
+          'event',
+          ['finding collabrators']
+        );
+        attendance3.saveAttendance((err) => {
+          if (err) {
+            console.log(err);
+          }
+          Attendance.searchAttendancesByUser('usertesting_1@user.com', (err, attendanceObj) => {
+            if (err) {
+              console.log('not able to get object');
+              console.log(err);
+            } else {
+              if(attendanceObj) {
+                assert.equal(attendanceObj[0].attendance_type, 'event');
+              }
+              else {
+                console.log("Attendance Object not found");
+              }
+            }
+            done();
+          });
+        });
+      }
+    });
+  });
+});
+
+describe('Attendance Read', () => {
+
+  before ((done) => {
+    const testexhibition1 = new Exhibition(
+      'MAMA! LAVA!',
+      'The description of the exhibition',
+      'STEPS',
+      'https://upload.wikimedia.org/wikipedia/en/0/02/My_Neighbor_Totoro_-_Tonari_no_Totoro_%28Movie_Poster%29.jpg',
+      ['https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1', 'https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1'],
+      ['www.youtube.com', 'www.youtube.com'],
+      'url.com',
+      ['game', 'software engineering'],
+    );
+    testexhibition1.saveExhibition((err, result) => {
+      if (err) {
+        console.log(err);
+      }
+      const attendance1 = new Attendance(
+        'usertesting_2@user.com',
+        result._id, 
+        'exhibition',
+        ['finding investors', 'finding collaborators']
+      );
+      attendance1.saveAttendance((err) => {
+        if (err) {
+          console.log(err);
+        }
+        done();
+      });
+    });
+  });
+
+  after((done) => {
+    Attendance.clearAllAttendances((err) =>{
+      if (err) {
+        console.log(err);
+      }
+      Exhibition.clearAllExhibitions((err) => {
+        if (err){
+          console.log(err);
+        }
+        done();
+      });
+    });
+  });
+
+  it('should be able to retrieve an array AttendanceObj by user email', (done) => {
+    Attendance.searchAttendancesByUser('usertesting_2@user.com', (err, obj) => {
+      if (err) {
+        console.log("unable to get attendance object");
+      } else {
+        assert.equal(obj[0].reason[0], 'finding investors');
       }
       done();
     });
   });
 
-  after(function(done) {
-    Attendance.clearAllAttendances(function callback(err) {
+  it('should be able to retrieve an array of AttendanceObj by attendance_key', (done) => {
+    Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
+      if (err){
+        console.log(err);
+        done();
+      } else{
+        Attendance.searchAttendancesByKey(result._id, (err, obj) => {
+          if (err) {
+            console.log("unable to get attendance object");
+          } else {
+            assert.equal(obj[0].attendance_type, 'exhibition');
+          }
+          done();
+        });
+      }
+    });
+  });
+
+  it('should be able to retrieve an array of AttendanceObj by reasons', (done) => {
+    Attendance.searchAttendancesByReason('investors', (err, obj) => {
+      if (err) {
+        console.log("unable to get attendance object");
+      } else {
+        assert.notEqual(obj, null);
+      }
+      done();
+    });
+  });
+
+  /**
+   * key can be used to get:
+   * list of guests (using event ID),
+   * list of teammates (using exhibition ID)
+   */ 
+  it('should be able to retrieve an array of AttendanceObj by attendance key and reasons', (done) => {
+    Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
+      if (err){
+        console.log(err);
+        done();
+      } else{
+        Attendance.searchAttendanceByKeyAndReason(result._id, 'investor', (err, obj) => {
+          if (err) {
+            console.log("unable to get attendance object");
+          } else {
+            assert.notEqual(obj, null);
+          }
+          done();
+        });
+      }
+    });
+  });
+
+
+  it('should be able to obtain a specific AttedanceObj using email and key', (done) => {
+    Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
+      if (err){
+        console.log(err);
+        done();
+      } else{
+        Attendance.getAttendance('usertesting_2@user.com',result._id, (err, obj) => {
+          if (err) {
+            console.log(err);
+          } else {
+            assert.equal(obj.attendance_type, 'exhibition');
+          }
+          done();
+        });
+      }
+    });
+  });
+});
+
+describe('Attendance Update', () => {
+
+  before ((done) => {
+    const testexhibition1 = new Exhibition(
+      'MAMA! LAVA!',
+      'The description of the exhibition',
+      'STEPS',
+      'https://upload.wikimedia.org/wikipedia/en/0/02/My_Neighbor_Totoro_-_Tonari_no_Totoro_%28Movie_Poster%29.jpg',
+      ['https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1', 'https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1'],
+      ['www.youtube.com', 'www.youtube.com'],
+      'url.com',
+      ['game', 'software engineering'],
+    );
+    testexhibition1.saveExhibition((err, result) => {
       if (err) {
         console.log(err);
       }
-      done();
-    })
-  });
-
-  it ('should be able to delete attendance', function(done) {
-    Attendance.deleteAttendance('usertesting_2@user.com', 
-                               'eventNumber2', 'exhibition', 
-                               function (err) {
-      if (err) {
-        console.log("unable to delete");
-      }
-      //check to see if it exist
-      Attendance.getAttendance('usertesting_2@user.com',
-                                  'eventNumber2', 'exhibition', function(err2, obj) {
-        if (err2) {
-          console.log("ERROR: unable to retrieve");
-        } else {
-          assert.equal(obj, null);
+      const attendance1 = new Attendance(
+        'usertesting_3@user.com',
+        result._id, 
+        'event',
+        ['finding investors', 'finding collabrators']
+      );
+      attendance1.saveAttendance((err) => {
+        if (err) {
+          console.log(err);
         }
         done();
       });
-    })
+    });
+  });
+
+  after((done) => {
+    Attendance.clearAllAttendances((err) =>{
+      if (err) {
+        console.log(err);
+      }
+      Exhibition.clearAllExhibitions((err) => {
+        if (err){
+          console.log(err);
+        }
+        done();
+      });
+    });
+  });
+
+  it('should be able to update reasons', (done) => {
+    Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
+      if (err){
+        console.log(err);
+        done();
+      } else{
+        Attendance.updateReason(
+          'usertesting_3@user.com',
+          result._id,
+          ['Finding internship', 'anything'],
+          (err, obj) => {
+            if (err) {
+              console.log(err);
+            } else if (obj){
+              assert.notEqual(obj,null);
+              assert.equal(obj.reason[0], 'Finding internship');
+            } else {
+              console.log("unable to find attendance object. Run test again");
+            }
+            done();
+          });
+      }
+    });
+  });
+
+});
+
+describe('Attendance Delete', () => {
+
+  before ((done) => {
+    const testexhibition1 = new Exhibition(
+      'MAMA! LAVA!',
+      'The description of the exhibition',
+      'STEPS',
+      'https://upload.wikimedia.org/wikipedia/en/0/02/My_Neighbor_Totoro_-_Tonari_no_Totoro_%28Movie_Poster%29.jpg',
+      ['https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1', 'https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1'],
+      ['www.youtube.com', 'www.youtube.com'],
+      'url.com',
+      ['game', 'software engineering'],
+    );
+    testexhibition1.saveExhibition((err, result) => {
+      if (err) {
+        console.log(err);
+      }
+      const attendance1 = new Attendance(
+        'usertesting_2@user.com',
+        result._id, 
+        'event',
+        ['finding investors', 'finding collabrators']
+      );
+      attendance1.saveAttendance((err) => {
+        if (err) {
+          console.log(err);
+        }
+        done();
+      });
+    });
+  });
+
+  after((done) => {
+    Attendance.clearAllAttendances((err) =>{
+      if (err) {
+        console.log(err);
+      }
+      Exhibition.clearAllExhibitions((err) => {
+        if (err){
+          console.log(err);
+        }
+        done();
+      });
+    });
+  });
+
+  it ('should be able to delete attendance', (done) =>  {
+    Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
+      if (err){
+        console.log(err);
+        done();
+      } else{
+        Attendance.deleteAttendance('usertesting_2@user.com', 
+                                    result._id, 
+                                    (err) => {
+          if (err) {
+            console.log("unable to delete");
+          }
+          //check to see if it exist
+          Attendance.searchAttendancesByUser('usertesting_2@user.com',
+                                             (err, obj) => {
+            if (err) {
+              console.log("ERROR: unable to retrieve");
+            } else {
+              assert.equal(obj[0], null);
+            }
+            done();
+          });
+        });
+      }
+    });
   });
 });

--- a/tests/comment.test.js
+++ b/tests/comment.test.js
@@ -61,12 +61,12 @@ describe('Comment Create', () => {
           'hey man thanks!',
           new Date('October 14, 2014 21:01:00'),
         );
-        testcomment2.saveComment(function callback(err, result) {
+        testcomment2.saveComment((err, result) => {
           if (err) {
             console.log(err);
           }
           // check that its inside the databse
-          Comment.getCommentsForExhibition(result.exhibition_key, function cb(err, commentObj){
+          Comment.getCommentsForExhibition(result.exhibition_key, (err, commentObj) => {
             if (err){
               console.log("error with getting comment for an event");
             } else {
@@ -80,8 +80,8 @@ describe('Comment Create', () => {
   });
 });
 
-describe('Comment Read', (done) => {
-  before(function(done) {
+describe('Comment Read', () => {
+  before((done) => {
     const testexhibition1 = new Exhibition(
       'EXI',
       'description',
@@ -145,9 +145,9 @@ describe('Comment Read', (done) => {
     })
   });
 
-  it('Should not be able to obtain comments from a non-existing exhibition', function(done){
+  it('Should not be able to obtain comments from a non-existing exhibition', (done) => {
     // non-existing exhibition means an invalid object ID
-    Comment.getCommentsForExhibition(1234567, function cb(err, commentObj){
+    Comment.getCommentsForExhibition(1234567, (err, commentObj) => {
       if (err){
         console.log("error with getting comment for an event");
       } else {
@@ -158,8 +158,8 @@ describe('Comment Read', (done) => {
   });
 });
 
-describe('Comment Update', function(){
-  before(function(done) {
+describe('Comment Update', () => {
+  before((done) => {
     const testexhibition1 = new Exhibition(
       'EXI',
       'description',
@@ -190,7 +190,7 @@ describe('Comment Update', function(){
     });
   });
 
-  after (function(done) {
+  after ((done) => {
     Exhibition.clearAllExhibitions((err) => {
       if (err) {
         console.log(err);
@@ -205,7 +205,7 @@ describe('Comment Update', function(){
   });
 
 
-  it ('should be able to append more comments into the object', function(done){
+  it ('should be able to append more comments into the object', (done)=> {
     Exhibition.getExhibition('EVENTNAME', 'EXI', (err, results) => {
       if (err) {
         console.log(err);
@@ -216,7 +216,7 @@ describe('Comment Update', function(){
           results._id,
           'I agree',
           new Date('October 14, 2014 22:20:20'),
-          function cb(err, results){
+          (err, results) => {
             if (err){
               console.log(err);
             } else {
@@ -228,4 +228,4 @@ describe('Comment Update', function(){
     })
   });
 
-});//*/
+});

--- a/tests/comment.test.js
+++ b/tests/comment.test.js
@@ -1,92 +1,153 @@
 const Comment = require("../server/database/objectClasses/Comment.js");
+const Exhibition = require("../server/database/objectClasses/Exhibition.js");
 const assert = require('assert');
 
-describe('Comment Create', function(){
-  before(function(done) {
-    var testcomment1 = new Comment('user1@user.com',
-                                   'MAMA! LAVA!',
-                                   'awesome!',
-                                   new Date('October 14, 2014 21:00:00'),
-                                  );
-
-    testcomment1.saveComment(function callback(err) {
+describe('Comment Create', () => {
+  before((done) => {
+    const testexhibition1 = new Exhibition(
+      'MAMA! LAVA!',
+      'description',
+      'STEPS',
+      'https://upload.wikimedia.org/wikipedia/en/0/02/My_Neighbor_Totoro_-_Tonari_no_Totoro_%28Movie_Poster%29.jpg',
+      ['https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1', 'https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1'],
+      ['www.youtube.com', 'www.youtube.com'],
+      'url.com',
+      ['game', 'software engineering'],
+    );
+    testexhibition1.saveExhibition((err, results) => {
       if (err) {
-        console.log(err);
+        console.log(err, results);
       }
-      done();
-    });
-  });
+      var testcomment1 = new Comment(
+        'user1@user.com',
+        results._id,
+        'awesome!',
+        new Date('October 14, 2014 21:00:00'),
+      );
 
-  after (function(done) {
-    Comment.clearAllComment(function cb(err) {
-      if (err) {
-        console.log(err);
-      }
-      done();
-    });
-  });
-
-  it('should be able to add a new message object', function(done){
-    var testcomment2 = new Comment('user2@user.com',
-                                   'MAMA! LAVA!',
-                                   'hey man thanks!',
-                                   new Date('October 14, 2014 21:01:00'),
-                                  );
-    testcomment2.saveComment(function callback(err) {
-      if (err) {
-        console.log(err);
-      }
-      // check that its inside the databse
-      Comment.getCommentsForExhibition('MAMA! LAVA!', function cb(err, commentObj){
-        if (err){
-          console.log("error with getting comment for an event");
-        } else {
-          assert.equal(commentObj[1].comments[0].content,'hey man thanks!');
+      testcomment1.saveComment((err) => {
+        if (err) {
+          console.log(err);
         }
         done();
       });
     });
   });
+
+  after ((done) => {
+    Exhibition.clearAllExhibitions((err) => {
+      if (err) {
+        console.log(err);
+      }
+      Comment.clearAllComments((err) => {
+        if (err) {
+          console.log(err);
+        }
+        done();
+      });
+    });
+  });
+
+  it('should be able to add a new message object', (done) => {
+    //first retrieve exhibition ID
+    Exhibition.getExhibition('STEPS', 'MAMA! LAVA!', (err, result) => {
+      if (err){
+        console.log(err);
+        done();
+      } else {
+        var testcomment2 = new Comment(
+          'user2@user.com',
+          result._id,
+          'hey man thanks!',
+          new Date('October 14, 2014 21:01:00'),
+        );
+        testcomment2.saveComment(function callback(err, result) {
+          if (err) {
+            console.log(err);
+          }
+          // check that its inside the databse
+          Comment.getCommentsForExhibition(result.exhibition_key, function cb(err, commentObj){
+            if (err){
+              console.log("error with getting comment for an event");
+            } else {
+              assert.equal(commentObj[1].comments[0].content,'hey man thanks!');
+            }
+            done();
+          });
+        });
+      }
+    });
+  });
 });
 
-describe('Comment Read', function(done){
+describe('Comment Read', (done) => {
   before(function(done) {
-    var testcomment3 = new Comment('user3@user.com',
-                                   'ExI',
-                                   'Could use work',
-                                   new Date('October 14, 2014 21:00:00'),
-                                  );
-
-    testcomment3.saveComment(function callback(err) {
+    const testexhibition1 = new Exhibition(
+      'EXI',
+      'description',
+      'EVENTNAME',
+      'https://upload.wikimedia.org/wikipedia/en/0/02/My_Neighbor_Totoro_-_Tonari_no_Totoro_%28Movie_Poster%29.jpg',
+      ['https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1', 'https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1'],
+      ['www.youtube.com', 'www.youtube.com'],
+      'url.com',
+      ['game', 'software engineering'],
+    );
+    testexhibition1.saveExhibition((err, results) => {
       if (err) {
-        console.log(err);
+        console.log(err, results);
       }
-      done();
+      var testcomment1 = new Comment('user1@user.com',
+                                     results._id,
+                                     'Could use work',
+                                     new Date('October 14, 2014 21:00:00'),
+                                    );
+
+      testcomment1.saveComment((err) => {
+        if (err) {
+          console.log(err);
+        }
+        done();
+      });
     });
   });
 
-  after (function(done) {
-    Comment.clearAllComment(function cb(err) {
+  after ((done) => {
+    Exhibition.clearAllExhibitions((err) => {
       if (err) {
         console.log(err);
       }
-      done();
+      Comment.clearAllComments((err) => {
+        if (err) {
+          console.log(err);
+        }
+        done();
+      });
     });
   });
 
-  it('Should be able to obtain date from an existing exhibition', function(done){
-    Comment.getCommentsForExhibition('ExI', function cb(err, commentObj){
-      if (err){
-        console.log("error with getting comment for an event");
+
+  it('Should be able to obtain comments from an existing exhibition', (done) => {
+    //obtain _id of exhibition
+    Exhibition.getExhibition('EVENTNAME', 'EXI', (err, results) => {
+      if (err) {
+        console.log(err);
+        done();
       } else {
-        assert.equal(commentObj[0].comments[0].content,'Could use work');
+        Comment.getCommentsForExhibition(results._id, (err, commentObj) => {
+          if (err){
+            console.log("error with getting comment for an event");
+          } else {
+            assert.equal(commentObj[0].comments[0].content,'Could use work');
+          }
+          done();
+        });
       }
-      done();
-    });
+    })
   });
 
-  it('Should not be able to obtain date from a non-existing exhibition', function(done){
-    Comment.getCommentsForExhibition('Exo', function cb(err, commentObj){
+  it('Should not be able to obtain comments from a non-existing exhibition', function(done){
+    // non-existing exhibition means an invalid object ID
+    Comment.getCommentsForExhibition(1234567, function cb(err, commentObj){
       if (err){
         console.log("error with getting comment for an event");
       } else {
@@ -96,45 +157,75 @@ describe('Comment Read', function(done){
     });
   });
 });
-//*/
+
 describe('Comment Update', function(){
   before(function(done) {
-    var testcomment3 = new Comment('user4@user.com',
-                                   'NAME',
-                                   'Could use work',
-                                   new Date('October 14, 2014 21:00:00'),
-                                  );
-
-    testcomment3.saveComment(function callback(err) {
+    const testexhibition1 = new Exhibition(
+      'EXI',
+      'description',
+      'EVENTNAME',
+      'https://upload.wikimedia.org/wikipedia/en/0/02/My_Neighbor_Totoro_-_Tonari_no_Totoro_%28Movie_Poster%29.jpg',
+      ['https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1', 'https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2Fp7HfgdZ.png&f=1'],
+      ['www.youtube.com', 'www.youtube.com'],
+      'url.com',
+      ['game', 'software engineering'],
+    );
+    testexhibition1.saveExhibition((err, results) => {
       if (err) {
-        console.log(err);
+        console.log(err, results);
       }
-      done();
+      var testcomment1 = new Comment(
+        'user4@user.com',
+        results._id,
+        'awesome!',
+        new Date('October 14, 2014 21:00:00'),
+      );
+
+      testcomment1.saveComment((err) => {
+        if (err) {
+          console.log(err);
+        }
+        done();
+      });
     });
   });
 
   after (function(done) {
-    Comment.clearAllComment(function cb(err) {
+    Exhibition.clearAllExhibitions((err) => {
       if (err) {
         console.log(err);
       }
-      done();
-    });
-  });
-
-  it ('should be able to append more comments into the object', function(done){
-    Comment.addCommentForExhibition(
-      'user4@user.com',
-      'NAME',
-      'I agree',
-      new Date('October 14, 2014 22:20:20'),
-      function cb(err, results){
-        if (err){
+      Comment.clearAllComments((err) => {
+        if (err) {
           console.log(err);
-        } else {
-          assert.equal(results.comments[1].content, 'I agree');
         }
         done();
       });
+    });
   });
-});
+
+
+  it ('should be able to append more comments into the object', function(done){
+    Exhibition.getExhibition('EVENTNAME', 'EXI', (err, results) => {
+      if (err) {
+        console.log(err);
+        done();
+      } else {
+        Comment.addCommentForExhibition(
+          'user4@user.com',
+          results._id,
+          'I agree',
+          new Date('October 14, 2014 22:20:20'),
+          function cb(err, results){
+            if (err){
+              console.log(err);
+            } else {
+              assert.equal(results.comments[1].content, 'I agree');
+            }
+            done();
+          });
+      }
+    })
+  });
+
+});//*/

--- a/tests/exhibition.test.js
+++ b/tests/exhibition.test.js
@@ -44,7 +44,7 @@ describe('Exhibition Create', () => {
       if (err) {
         console.log(err);
       }
-      Exhibition.getExhibition('exhibitionTest3', (err, doc) => {
+      Exhibition.getExhibition('testingEvent_1', 'exhibitionTest3', (err, doc) => {
         if (err) {
           console.log('Unable to execute getExhibition function properly');
         }
@@ -86,7 +86,7 @@ describe('Exhibition Read', () => {
 
 
   it('Should be able to retrieve an existing object', (done) => {
-    Exhibition.getExhibition('exhibitionTest2', (err, doc) => {
+    Exhibition.getExhibition('eventName2', 'exhibitionTest2', (err, doc) => {
       if (err) {
         console.log('Unable to execute getExhibition function properly');
       } else {
@@ -97,7 +97,7 @@ describe('Exhibition Read', () => {
   });
 
   it('Should not be able to retrieve a non-existing object', (done) => {
-    Exhibition.getExhibition('exhibitionTest4', (err, doc) => {
+    Exhibition.getExhibition('eventName2', 'exhibitionTest4', (err, doc) => {
       if (err) {
         console.log('Unable to execute getExhibition function properly');
       } else {
@@ -108,7 +108,7 @@ describe('Exhibition Read', () => {
   });
 
   it('should be able to identify if its an existing exhibition', (done) => {
-    Exhibition.isExistingExhibition('exhibitionTest2', (err, doc) => {
+    Exhibition.isExistingExhibition('eventName2', 'exhibitionTest2', (err, doc) => {
       if (err) {
         console.log('error with isExisting');
       } else {
@@ -119,7 +119,7 @@ describe('Exhibition Read', () => {
   });
 
   it('should be able to identify if its an existing exhibition', (done) => {
-    Exhibition.isExistingExhibition('exhibitionTest4', (err, doc) => {
+    Exhibition.isExistingExhibition('eventName2', 'exhibitionTest4', (err, doc) => {
       if (err) {
         console.log('error with isExisting');
       } else {
@@ -192,17 +192,12 @@ describe('Exhibition Update', () => {
                                 ['www.youtube.com', 'www.youtube.com'],
                                 'url.com',
                                 ['software engineering', 'android'],
-                                (err) => {
+                                (err, result) => {
       if (err) {
         console.log('unable to update');
       }
-      Exhibition.getExhibition('exhibitionTest2', (err, obj) => {
-        if (err) {
-          console.log('unable to get exhibition in update existing unit test');
-        }
-        assert.equal('updated description', obj.exhibition_description);
-        done();
-      });
+      assert.equal('updated description', result.exhibition_description);
+      done();
     });
   });
 });
@@ -243,7 +238,7 @@ describe('Exhibition Delete', () => {
       }
 
       // Checks to see if it's removed
-      Exhibition.getExhibition('exhibitionTest1', (err, obj) => {
+      Exhibition.getExhibition('eventName2', 'exhibitionTest1', (err, obj) => {
         if (err) {
           console.log('unable to get exhibition in update existing unit test');
         } else {


### PR DESCRIPTION
Some parts of our previous implementation assumed that the exhibition_name attribute under each Exhibition Document was unique. This is not the case. 

Instead, either the Exhibition ID itself, or the Exhibition's exhibition_name and the Exhibition's event_name should be used as a unique identifier. Affected Schemas and ObjectClasses include: 
1) Attendance: attendance_name => attendance_key, which holds either the Event or Exhibition ID.
2) Comments: exhibition_name => exhibition_key, which holds an Exhibition ID.