### PR TITLE
#173 establish router

### DIFF
--- a/server/database/objectClasses/Attendance.js
+++ b/server/database/objectClasses/Attendance.js
@@ -189,7 +189,7 @@ class Attendance {
    * @param {function} callback: A function that executes once the
    *    operation is done.
    */
-  static searchAttendanceByKeyAndReason(attendanceKey, reason, callback) {
+  static searchAttendancesByKeyAndReason(attendanceKey, reason, callback) {
     Attendance.connectDB();
     const query = { attendance_key: attendanceKey,
       reason: { $regex: new RegExp(reason.trim().toLowerCase().replace('+', '\\+'), 'i') },

--- a/server/database/objectClasses/Comment.js
+++ b/server/database/objectClasses/Comment.js
@@ -87,6 +87,25 @@ class Comment {
     });
   }
 
+    /**
+   * Retrieve list of Comments for a specific Exhibition.
+   *
+   * @param {String} userEmail: The unique email used to identify user
+   * @param {mongoose.Schema.ObjectId} exhibitionKey: The ObjectID of the Exhibition.
+   * @param {function} callback: A function that is executed once the operation is done.
+   */
+  static getUserCommentsForExhibition(userEmail, exhibitionKey, callback) {
+    const query = {
+      user_email: userEmail,
+      exhibition_key: exhibitionKey,
+    }
+    Comment.connectDB();
+    this.CommentModel.findOne(query, (err, matchedComments) => {
+      Comment.disconnectDB();
+      callback(err, matchedComments);
+    });
+  }
+  
   /**
    * Retrieve list of Comments for a specific Exhibition.
    *

--- a/server/routes/attendance.js
+++ b/server/routes/attendance.js
@@ -51,7 +51,7 @@ router.get('/get/oneEventAttendances/:eventName', (req = {}, res, next) => {
                   }
                 });
           } else {
-            res.status(200).json([]);
+            res.status(204).json('Nothing found!');
             next();
           }
         });
@@ -100,7 +100,7 @@ router.get('/get/oneExhibitionParticipants/:eventName/:exhibitionName', (req = {
                               }
                             });
           } else {
-            res.status(200).json([]);
+            res.status(204).json('Nothing found!');
             next();
           }
         });
@@ -163,7 +163,7 @@ router.get('/get/oneUserAttendances/:email', (req = {}, res, next) => {
               }
             });
       } else {
-        res.status(200).json([]);
+        res.status(204).json('Nothing found!');
         next();
       }
     });
@@ -213,7 +213,7 @@ router.get('/get/oneUserEventAttendances/:email', (req = {}, res, next) => {
               }
             });
       } else {
-        res.status(200).json([]);
+        res.status(204).json('Nothing found!');
         next();
       }
     });
@@ -265,7 +265,7 @@ router.get('/get/oneUserAttendancesForEvent/:email/:eventName', (req = {}, res, 
               }
             });
       } else {
-        res.status(200).json([]);
+        res.status(204).json('Nothing found!');
         next();
       }
     });
@@ -283,7 +283,7 @@ router.post('/post/search/oneEventAttendancesWithReason/', (req = {}, res, next)
         res.status(500).json('Unable to process data!');
         next();
       } else if (event) {
-        Attendance.searchAttendanceByKeyAndReason(event._id,
+        Attendance.searchAttendancesByKeyAndReason(event._id,
                     req.body.reason, (err, attendances) => {
                       if (err) {
                         res.status(500).json('Unable to process data!');
@@ -309,7 +309,7 @@ router.post('/post/search/oneEventAttendancesWithReason/', (req = {}, res, next)
                                   }
                                 });
                       } else {
-                        res.status(200).json([]);
+                        res.status(204).json('Nothing found!');
                         next();
                       }
                     });
@@ -338,7 +338,7 @@ router.post('/post/set/oneAttendanceReasons', (req = {}, res, next) => {
         res.status(200).json(extractAttendanceInfo(attendance));
         next();
       } else {
-        res.status(204).json('Unable to find attendance for specified User and Event / Exhibition');
+        res.status(204).json('Nothing found!');
         next();
       }
     });

--- a/server/routes/attendance.js
+++ b/server/routes/attendance.js
@@ -34,7 +34,7 @@ router.get('/get/oneAttendanceAttendees/:id', (req = {}, res, next) => {
                           if (err) {
                             callback(null, null);
                           } else if (user) {
-                            callback(null, user);
+                            callback(null, extractUserInfo(user));
                           } else {
                             callback(null, null);
                           }

--- a/server/routes/attendance.js
+++ b/server/routes/attendance.js
@@ -8,12 +8,15 @@ const Event = require('../database/objectClasses/Event');
 const Exhibition = require('../database/objectClasses/Exhibition');
 const Attendance = require('../database/objectClasses/Attendance');
 
+// Note: Attendance Routes return JSON objects with key names
+//    that differ from the User, Event, Exhibition and Attendance Schemas.
+// See extractExhibitionInfo under ../utils/utils to see actual conversion
 const extractUserInfo = require('../utils/utils').extractUserInfo;
 const extractEventInfo = require('../utils/utils').extractEventInfo;
 const extractExhibitionInfo = require('../utils/utils').extractExhibitionInfo;
 const extractAttendanceInfo = require('../utils/utils').extractAttendanceInfo;
 
-// All Routes prefixed with 'attendance/'
+// Note: All Routes prefixed with 'attendance/'
 
 // Get the Users attending an Event
 router.get('/get/oneEventAttendances/:eventName', (req = {}, res, next) => {

--- a/server/routes/attendance.js
+++ b/server/routes/attendance.js
@@ -9,7 +9,7 @@ const Exhibition = require('../database/objectClasses/Exhibition');
 const Attendance = require('../database/objectClasses/Attendance');
 
 // Note: Attendance Routes return JSON objects with key names
-//    that differ from the User, Event, Exhibition and Attendance Schemas.
+//       that differ from the User, Event, Exhibition and Attendance Schemas.
 // See extractExhibitionInfo under ../utils/utils to see actual conversion
 const extractUserInfo = require('../utils/utils').extractUserInfo;
 const extractEventInfo = require('../utils/utils').extractEventInfo;

--- a/server/routes/comment.js
+++ b/server/routes/comment.js
@@ -2,36 +2,103 @@ const express = require('express');
 
 const router = new express.Router();
 
+const extractCommentInfo = require('../utils/utils').extractCommentInfo;
+
 const Comment = require('../database/objectClasses/Comment');
 
-router.post('/post/newComment', (req = {}, res, next) => {
-  const newComment = new Comment(
-      req.body.userEmail, req.body.exhibitionName, req.body.comment, Date.now());
-  newComment.saveComment((err) => {
+const Exhibition = require('../database/objectClasses/Exhibition');
+
+router.get('/get/userComments/:eventName/:exhibitionName/:userEmail', (req = {}, res, next) => {
+  Exhibition.getExhibition(req.params.eventName, req.params.exhibitionName, (err, result) => {
     if (err) {
-      res.status(500).json('Unable to save data!');
-      next();
+      res.status(500).json('Unable to fetch' + req.params.exhibitionName);
+    } else if (result){
+      Comment.getUserCommentsForExhibition(req.params.userEmail, result._id, (err, commentObj) => {
+        if (err) {
+          res.status(500).json('unable to fetch Comment object for '+ req.params.userEmail);
+        } else if (commentObj) {
+          res.status(200).json(extractCommentInfo(commentObj));
+        } else {
+          res.status(404).json('Comment object not found for '+req.params.userEmail);
+        }
+      });
     } else {
-      res.status(200).send('Added');
-      next();
+      res.status(404).json('unable to find '+req.params.exhibitionName+ ' object');
     }
   });
 });
 
-router.post('/post/addComment', (req = {}, res, next) => {
-  Comment.addCommentForExhibition(
-      req.body.userEmail, req.body.exhibitionName, req.body.comment, Date.now(), (err, results) => {
+router.get('/get/:eventName/:exhibitionName', (req = {}, res, next) => {
+  Exhibition.getExhibition(req.params.eventName, req.params.exhibitionName, (err, result) => {
+    if (err) {
+      res.status(500).json('Unable to fetch' + req.params.exhibitionName);
+    } else if (result){
+      Comment.getCommentsForExhibition(result._id, (err, commentObjs) => {
         if (err) {
-          res.status(500).json('Unable to fetch data!');
-          next();
-        } else if (results) {
-          res.status(200).send('Added');
-          next();
+          res.status(500).json('unable to fetch Comment object for '+ req.params.userEmail);
+        } else if (commentObjs) {
+          res.status(200).json(commentObjs.map(commentObj => extractCommentInfo(commentObj)));
         } else {
-          res.status(404).json('Comment object not found!');
-          next();
+          res.status(404).json('Comment object not found for '+req.params.userEmail);
         }
       });
+    } else {
+      res.status(404).json('unable to find '+req.params.exhibitionName+ ' object');
+    }
+  });
+});
+
+router.post('/post/newComment', (req = {}, res, next) => {
+  if (req.body && req.body.eventName && req.body.exhibitionName && req.body.userEmail && req.body.comment){
+    Exhibition.getExhibition(req.body.eventName, req.body.exhibitionName, (err, results) => {
+      if (err) {
+        res.status(500).json('Unable to fetch the exhibition id');
+      } else if (results) {
+        const newComment = new Comment(
+          req.body.userEmail, results._id, req.body.comment, Date.now());
+        newComment.saveComment((err) => {
+          if (err) {
+            res.status(500).json('Unable to save data!');
+            next();
+          } else {
+            res.status(200).json('Added');
+            next();
+          }
+        });
+      } else {
+        res.status(404).json('Unable to find ' + req.body.exhibitionName + ' object');
+      }
+    });
+  } else {
+    res.status(400).json('Bad request! Expecting "exhibitionName", "eventName", "userEmail" and "comment"');
+  }
+});
+
+router.post('/post/addComment', (req = {}, res, next) => {
+  if (req.body && req.body.exhibitionName && req.body.eventName && req.body.userEmail && req.body.comment){
+    Exhibition.getExhibition(req.body.eventName, req.body.exhibitionName, (err, results) => {
+      if (err) {
+        res.status(500).json('Unable to fetch the exhibition id');
+      } else if (results) {
+        Comment.addCommentForExhibition(req.body.userEmail, results._id, req.body.comment, Date.now(), (err, results) => {
+          if (err) {
+            res.status(500).json('Unable to fetch Comment object for ' + req.body.exhibitionName);
+            next();
+          } else if (results) {
+            res.status(200).json('Added');
+            next();
+          } else {
+            res.status(404).json('Comment object not found!');
+            next();
+          }
+        });
+      } else {
+        res.status(404).json('Unable to find ' + req.body.exhibitionName + ' object');
+      }
+    });
+  } else {
+    res.status(400).json('Bad request! Expecting "exhibitionName", "eventName", "userEmail" and "comment"');
+  }
 });
 
 module.exports = router;

--- a/server/routes/event.js
+++ b/server/routes/event.js
@@ -17,7 +17,7 @@ router.get('/get/allEvents', (req = {}, res, next) => {
       res.status(200).json(eventObjs.map(eventObj => extractEventInfo(eventObj)));
       next();
     } else {
-      res.status(404).json('Nothing found!');
+      res.status(204).json('Nothing found!');
       next();
     }
   });
@@ -32,7 +32,7 @@ router.get('/get/oneEvent/:eventName', (req = {}, res, next) => {
       res.status(200).json(extractEventInfo(eventObj));
       next();
     } else {
-      res.status(404).json('Nothing found!');
+      res.status(204).json('Nothing found!');
       next();
     }
   });
@@ -47,7 +47,7 @@ router.get('/get/searchTag/:tag', (req = {}, res, next) => {
       res.status(200).json(eventObjs.map(eventObj => extractEventInfo(eventObj)));
       next();
     } else {
-      res.status(404).json('Nothing found!');
+      res.status(204).json('Nothing found!');
       next();
     }
   });
@@ -61,7 +61,7 @@ router.post('/post/updateMap', (req = {}, res, next) => {
       } else if (results) {
         res.status(200).send('Added!');
       } else {
-        res.status(404).json('Message object not found!');
+        res.status(204).json('Message object not found!');
       }
       next();
     });
@@ -78,7 +78,7 @@ router.post('/post/updateEventPicture', (req = {}, res, next) => {
       } else if (results) {
         res.status(200).send('Added!');
       } else {
-        res.status(404).json('Message object not found!');
+        res.status(204).json('Message object not found!');
       }
       next();
     });
@@ -96,7 +96,7 @@ router.post('/post/updateTags', (req = {}, res, next) => {
       } else if (results) {
         res.status(200).send('Added!');
       } else {
-        res.status(404).json('Message object not found!');
+        res.status(204).json('Message object not found!');
       }
       next();
     });

--- a/server/routes/exhibition.js
+++ b/server/routes/exhibition.js
@@ -19,7 +19,7 @@ router.get('/get/allExhibitions', (req = {}, res, next) => {
     } else if (exhibitions) {
       res.status(200).json(exhibitions.map(exhibition => extractExhibitionInfo(exhibition)));
     } else {
-      res.status(404).json('Nothing found!');
+      res.status(204).json('Nothing found!');
     }
     next();
   });
@@ -34,7 +34,7 @@ router.get('/get/oneEventExhibitions/:eventName', (req = {}, res, next) => {
       } else if (exhibitions) {
         res.status(200).json(exhibitions.map(exhibition => extractExhibitionInfo(exhibition)));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -53,7 +53,7 @@ router.get('/get/oneExhibition/:eventName/:exhibitionName', (req = {}, res, next
       } else if (exhibition) {
         res.status(200).json(extractExhibitionInfo(exhibition));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -77,7 +77,7 @@ router.get('/get/oneExhibitionById/:exhibitionId', (req = {}, res, next) => {
       } else if (exhibition) {
         res.status(200).json(extractExhibitionInfo(exhibition));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -101,7 +101,7 @@ router.post('/post/search/tag', (req = {}, res, next) => {
       } else if (exhibitions) {
         res.status(200).json(exhibitions.map(exhibition => extractExhibitionInfo(exhibition)));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -129,7 +129,7 @@ router.post('/post/oneExhibition/set/tags', (req = {}, res, next) => {
               } else if (exhibition) {
                 res.status(200).json(extractExhibitionInfo(exhibition));
               } else {
-                res.status(404).json('Nothing found!');
+                res.status(204).json('Nothing found!');
               }
               next();
             });

--- a/server/routes/exhibition.js
+++ b/server/routes/exhibition.js
@@ -4,9 +4,12 @@ const router = new express.Router();
 
 const Exhibition = require('../database/objectClasses/Exhibition');
 
+// Note: Exhibition Routes return JSON objects with key names
+//       that differ from the Exhibition Mongoose Schema:
+// See extractExhibitionInfo under ../utils/utils to see actual conversion
 const extractExhibitionInfo = require('../utils/utils').extractExhibitionInfo;
 
-// All Routes prefixed with 'exhibition/'
+// Note: All Routes prefixed with 'exhibition/'
 
 router.get('/get/allExhibitions', (req = {}, res, next) => {
   Exhibition.getAllExhibitions((err, exhibitions) => {

--- a/server/routes/message.js
+++ b/server/routes/message.js
@@ -16,7 +16,7 @@ router.get('/get/getMessages/:senderEmail/:recipientEmail', (req = {}, res, next
           messages: msgObjs.messages,
         });
       } else {
-        res.status(404).json('Message object from '+ req.params.senderEmail+ ' to '+ req.params.recipientEmail+ ' was not found!');
+        res.status(204).json('Message object from '+ req.params.senderEmail+ ' to '+ req.params.recipientEmail+ ' was not found!');
       }  
       next();
     });
@@ -36,7 +36,7 @@ router.get('/get/getMessagesFrom/:senderEmail', (req = {}, res, next) => {
           emails: msgObj.recipient_email,
         })));
       } else {
-        res.status(404).json('Message object from '+ req.params.senderEmail+ ' was not found!');
+        res.status(204).json('Message object from '+ req.params.senderEmail+ ' was not found!');
       }
       next();
     });
@@ -57,7 +57,7 @@ router.get('/get/getMessagesTo/:recipientEmail', (req = {}, res, next) => {
           emails: msgObj.sender_email,
         })));
       } else {
-        res.status(404).json('Message object to '+req.params.recipientEmail+' was not found!');
+        res.status(204).json('Message object to '+req.params.recipientEmail+' was not found!');
       }
       next();
     });
@@ -75,7 +75,7 @@ router.get('/get/getMessagesInvolving/:userEmail', (req = {}, res, next) => {
       } else if (msgObjs[0]) {
         res.status(200).json(msgObjs);
       } else {
-        res.status(404).json(req.params.userEmail + ' not found!');
+        res.status(204).json(req.params.userEmail + ' not found!');
       }
       next();
     });

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -20,7 +20,7 @@ router.get('/get/profile/:email', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -44,7 +44,7 @@ router.post('/post/search/skill', (req = {}, res, next) => {
       } else if (users) {
         res.status(200).json(users.map(user => extractUserInfo(user)));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -68,7 +68,7 @@ router.post('/post/profile/set/description', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -92,7 +92,7 @@ router.post('/post/profile/set/picture', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -117,7 +117,7 @@ router.post('/post/profile/set/notification', (req = {}, res, next) => {
           } else if (user) {
             res.status(200).json(extractUserInfo(user));
           } else {
-            res.status(404).json('Nothing found!');
+            res.status(204).json('Nothing found!');
           }
           next();
         });
@@ -141,7 +141,7 @@ router.post('/post/profile/add/skill', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -165,7 +165,7 @@ router.post('/post/profile/add/bUser', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -189,7 +189,7 @@ router.post('/post/profile/remove/skill', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -213,7 +213,7 @@ router.post('/post/profile/remove/bUser', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -240,7 +240,7 @@ router.post('/post/profile/set/skills', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });
@@ -264,7 +264,7 @@ router.post('/post/profile/set/bUsers', (req = {}, res, next) => {
       } else if (user) {
         res.status(200).json(extractUserInfo(user));
       } else {
-        res.status(404).json('Nothing found!');
+        res.status(204).json('Nothing found!');
       }
       next();
     });

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -4,9 +4,12 @@ const router = new express.Router();
 
 const User = require('../database/objectClasses/User');
 
+// Note: User Routes return JSON objects with key names
+//       that differ from the User Mongoose Schema:
+// See extractUserInfo under ../utils/utils to see actual conversion
 const extractUserInfo = require('../utils/utils').extractUserInfo;
 
-// All Routes prefixed with 'user/'
+// Note: All Routes prefixed with 'user/'
 
 router.get('/get/profile/:email', (req = {}, res, next) => {
   if (req.params && req.params.email) {

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -101,7 +101,7 @@ module.exports.extractAttendanceInfo = extractAttendanceInfo;
  *
  * @param {Comment.Object} comment:
  *    The Comment Object returned from a Comment objectClass method.
- * @returns {{id, userEmail, comments: {postSchema.object: _id, content, time}}
+ * @returns {{id, userEmail, comments}}
  */
 function extractCommentInfo(comment) {
   return {

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -96,3 +96,19 @@ function extractAttendanceInfo(attendance) {
 
 module.exports.extractAttendanceInfo = extractAttendanceInfo;
 
+/**
+ * Extracts out relevant information from a supplied Comment Object.
+ *
+ * @param {Comment.Object} comment:
+ *    The Comment Object returned from a Comment objectClass method.
+ * @returns {{id, userEmail, comments: {postSchema.object: _id, content, time}}
+ */
+function extractCommentInfo(comment) {
+  return {
+    id: comment._id,
+    userEmail: comment.user_email,
+    comments: comment.comments,
+  };
+}
+
+module.exports.extractCommentInfo = extractCommentInfo;

--- a/tests/attendance.test.js
+++ b/tests/attendance.test.js
@@ -239,7 +239,7 @@ describe('Attendance Read', () => {
         console.log(err);
         done();
       } else{
-        Attendance.searchAttendanceByKeyAndReason(result._id, 'investor', (err, obj) => {
+        Attendance.searchAttendancesByKeyAndReason(result._id, 'investor', (err, obj) => {
           if (err) {
             console.log("unable to get attendance object");
           } else {


### PR DESCRIPTION
Added more Attendance Routes:
1) getOneAttendanceAttendees - a GET route that returns the Users in a given Event or Exhibition. This route should be used as it is more efficient than the routes which deal with those separately (getOneEventAttendees and getOneExhibitionParticipants).
2) getOneEventExhibitors - a GET route that returns all the Users of a specified Event that are participating in at least one Exhibition in said Event. Can be used, but extremely inefficient at current incarnation.

All User, Exhibition, and Attendance routes now returns 204 rather than 404 when the route cannot find any results.